### PR TITLE
🐛 Fix jagged images when downscaling

### DIFF
--- a/lib/widgets/pokemon_card_widget.dart
+++ b/lib/widgets/pokemon_card_widget.dart
@@ -89,7 +89,9 @@ class _PokemonCardState extends State<PokemonCard> {
           ]),
           Expanded(
             child: Image.network(widget.pokemon.artwork,
-                scale: 1, isAntiAlias: true, filterQuality: FilterQuality.high),
+                scale: 1,
+                isAntiAlias: true,
+                filterQuality: FilterQuality.medium),
           ),
           SizedBox(
             height: 40,


### PR DESCRIPTION
As written in my messages on the r/FlutterDev Discord server, filter quality corresponded to different image scaling algorithm:
`FilterQuality.high` using Mipmap
`FliterQuality.medium` using Bilinear

As from what I've tried, seems like Bilinear is the right choice for this kind of scaling.